### PR TITLE
Only copy `self.size` samples in FftStream::work

### DIFF
--- a/src/fft_stream.rs
+++ b/src/fft_stream.rs
@@ -47,7 +47,7 @@ impl Block for FftStream {
         if oo.len() < self.size {
             return Ok(BlockRet::Ok);
         }
-        oo.copy_from_slice(ii);
+        oo[..self.size].copy_from_slice(&ii[..self.size]);
         self.fft.process(oo);
         input.consume(self.size);
         o.produce(self.size, &[]);


### PR DESCRIPTION
Possible fix for #9 

Feel free to close if this is the wrong solution :)